### PR TITLE
Make printed order prices bold

### DIFF
--- a/src/modules/common.ts
+++ b/src/modules/common.ts
@@ -689,15 +689,18 @@ export const printOptionDetails = (
     );
     lines.forEach((wrapped, idx) => {
       const isLast = idx === lines.length - 1;
+      const hasPrice = isLast && priceStr.length > 0;
       let out = wrapped;
-      if (isLast && priceStr.length > 0) {
+      if (hasPrice) {
         const padded =
           out.length + priceStr.length <= lineWidth
             ? out.padEnd(lineWidth - priceStr.length)
             : out;
         out = padded + priceStr;
       }
+      if (hasPrice) printer.bold(true);
       printer.println(tr(out, settings.transliterate));
+      if (hasPrice) printer.bold(false);
     });
   });
 };
@@ -778,9 +781,11 @@ export const printProductDiscount = (
       discountText = `${discount.amount}%`;
     }
     if (discountText) {
+      printer.bold(true);
       printer.println(
         `${indent}${tr(`${translations.printOrder.discount[lang]}`, transliterate)}: -${discountText}`
       );
+      printer.bold(false);
     }
   }
 };
@@ -884,6 +889,7 @@ export const printProducts = (
 
         if (i === 0) {
           // First line → quantity first
+          printer.bold(true);
           printer.println(
             quantity.padEnd(7) +
               chunk.padEnd(maxNameLength) +
@@ -891,6 +897,7 @@ export const printProducts = (
               value.padStart(7) +
               vat.padStart(10)
           );
+          printer.bold(false);
         } else {
           // Subsequent lines → only print name aligned after quantity
           printer.println(' '.repeat(7) + chunk);
@@ -898,6 +905,7 @@ export const printProducts = (
       }
     } else {
       // Short name → print in one line with quantity first
+      printer.bold(true);
       printer.println(
         quantity.padEnd(7) +
           name.padEnd(maxNameLength) +
@@ -905,6 +913,7 @@ export const printProducts = (
           value.padStart(7) +
           vat.padStart(10)
       );
+      printer.bold(false);
     }
     if (
       showOptions &&
@@ -980,17 +989,21 @@ export const printDiscountAndTip = (
         discountAmount = discount.amount.toString() + '%';
       }
       if (discountAmount !== '') {
+        printer.bold(true);
         printer.println(
           `${tr(`${translations.printOrder.discount[lang]}`, transliterate)}: ${discountAmount}, ${tr(DISCOUNTTYPES[discount.type.toLocaleLowerCase()]?.label_el || '', transliterate)}`
         );
+        printer.bold(false);
       }
     }
   });
 
   if (tip > 0) {
+    printer.bold(true);
     printer.println(
       `${tr(`${translations.printOrder.tip[lang]}`, transliterate)}: ${(tip / 100).toFixed(2)}€`
     );
+    printer.bold(false);
   }
 };
 
@@ -1014,9 +1027,11 @@ export const printVatBreakdown = (
   );
 
   vatBreakdown.forEach((entry) => {
+    printer.bold(true);
     printer.println(
       `${String(entry.vat).padEnd(10)}${String(entry.netValue.toFixed(2)).padEnd(12)}${String(entry.vatAmount.toFixed(2)).padEnd(10)}${String(entry.total.toFixed(2)).padStart(10)}`
     );
+    printer.bold(false);
   });
 
   drawLine2(printer);

--- a/src/modules/printer.ts
+++ b/src/modules/printer.ts
@@ -3459,9 +3459,11 @@ export const printOrder = async (
             ' '
           );
 
+          if (priceStr) printer.bold(true);
           printer.println(
             `${tr(paddedLine, settings.transliterate)}${priceStr}`
           );
+          if (priceStr) printer.bold(false);
 
           // Handle product option details
           if (
@@ -3556,9 +3558,11 @@ export const printOrder = async (
             settings.priceOnOrder === true
           ) {
             printer.alignRight();
+            printer.bold(true);
             printer.println(
               `${convertToDecimal((total + choicesTotal) * Math.abs(printQuantity)).toFixed(2)} €`
             );
+            printer.bold(false);
           }
           printer.alignLeft();
 
@@ -3680,9 +3684,11 @@ export const printOrder = async (
 
         if (order.tip && settings.priceOnOrder) {
           printer.newLine();
+          printer.bold(true);
           printer.println(
             `${tr(`${translations.printOrder.tip[lang]}`, settings.transliterate)}:${convertToDecimal(order.tip).toFixed(2)} €`
           );
+          printer.bold(false);
         }
 
         // Overall discounts (not per-product)
@@ -3700,9 +3706,11 @@ export const printOrder = async (
             settings.priceOnOrder === true)
         ) {
           printer.newLine();
+          printer.bold(true);
           printer.println(
             `${tr(`${translations.printOrder.deliveryFee[lang]}`, settings.transliterate)}:${convertToDecimal(order.deliveryInfo.deliveryFee).toFixed(2)} €`
           );
+          printer.bold(false);
         }
         printer.alignRight();
         // Calculate total without VAT (net values)
@@ -3716,9 +3724,11 @@ export const printOrder = async (
           settings.vatAnalysis === undefined
         ) {
           // Print total without VAT
+          printer.bold(true);
           printer.println(
             `${tr(`${translations.printOrder.netWithoutVat[lang]}`, settings.transliterate)}:${totalNetValue.toFixed(2)} €`
           );
+          printer.bold(false);
         }
         // Calculate total discount amount for overall discounts
         let totalDiscountAmount = 0;
@@ -3739,9 +3749,11 @@ export const printOrder = async (
           settings.priceOnOrder === true
         ) {
           const totalAfterDiscounts = order.total - totalDiscountAmount;
+          printer.bold(true);
           printer.println(
             `${tr(`${translations.printOrder.total[lang]}`, settings.transliterate)}:${convertToDecimal(totalAfterDiscounts).toFixed(2)} €`
           );
+          printer.bold(false);
         }
 
         // Delivery-assignment QR: a delivery person scans it to open the order


### PR DESCRIPTION
Task: https://partners.flarmio.com/admin/dev/tasks/6a490d12041c1bcca7249b78

## Summary
- Bold order-ticket price lines when prices are printed
- Bold option prices, discounts, tips, delivery fee, VAT price rows, and the final total

## Verification
- Not run (per instruction: no builds/tests/lint/typecheck)