### PR TITLE
feat: pull print jobs from backend over long-poll

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
   tryFetchWithFallback,
 } from './modules/http';
 import { paymentMyPelatesReceipt } from './modules/printer';
+import { initPullClient } from './modules/pullClient';
 import { initWebSocketClient, setRestartHandler } from './modules/wsClient';
 
 const main = async () => {
@@ -342,8 +343,11 @@ const main = async () => {
       );
     }
 
-    // Connect to backend via WebSocket for receiving print commands
+    // Connect to backend via WebSocket for liveness/control and test-page pushes
     initWebSocketClient();
+
+    // Primary print-job channel: long-poll the backend and pull jobs to print
+    initPullClient();
   });
 };
 

--- a/src/modules/backendUrl.ts
+++ b/src/modules/backendUrl.ts
@@ -10,13 +10,16 @@ nconf.argv().env().file({ file: './config.json' });
 const DEFAULT_API_URL = 'https://api.quickord.com/graphql';
 
 // Backend HTTP base (no /graphql). Overridable via BACKEND_HTTP_URL for
-// non-standard deployments. The anchored regex only strips a trailing
-// /graphql, so a host like graphql.example.com survives intact.
+// non-standard deployments. The anchored /graphql regex only strips a trailing
+// /graphql, so a host like graphql.example.com survives intact; the final
+// trailing-slash strip keeps a copy-pasted "http://host/" from producing
+// //-doubled paths that some proxies route as a different endpoint.
 export function getBackendBaseUrl(): string {
-  const explicit = nconf.get('BACKEND_HTTP_URL');
-  if (explicit) return explicit;
-  const apiUrl = nconf.get('QUICKORD_API_URL') || DEFAULT_API_URL;
-  return apiUrl.replace(/\/graphql\/?$/, '');
+  const base =
+    nconf.get('BACKEND_HTTP_URL') ||
+    nconf.get('QUICKORD_API_URL') ||
+    DEFAULT_API_URL;
+  return base.replace(/\/graphql\/?$/, '').replace(/\/+$/, '');
 }
 
 // Backend WebSocket URL, derived from the same base. Overridable via

--- a/src/modules/backendUrl.ts
+++ b/src/modules/backendUrl.ts
@@ -1,0 +1,30 @@
+/**
+ * Single source for deriving backend endpoints from QUICKORD_API_URL, so the
+ * WebSocket channel and the HTTP pull channel can never point at different
+ * hosts (they previously each re-derived the base with different strip rules).
+ */
+import nconf from 'nconf';
+
+nconf.argv().env().file({ file: './config.json' });
+
+const DEFAULT_API_URL = 'https://api.quickord.com/graphql';
+
+// Backend HTTP base (no /graphql). Overridable via BACKEND_HTTP_URL for
+// non-standard deployments. The anchored regex only strips a trailing
+// /graphql, so a host like graphql.example.com survives intact.
+export function getBackendBaseUrl(): string {
+  const explicit = nconf.get('BACKEND_HTTP_URL');
+  if (explicit) return explicit;
+  const apiUrl = nconf.get('QUICKORD_API_URL') || DEFAULT_API_URL;
+  return apiUrl.replace(/\/graphql\/?$/, '');
+}
+
+// Backend WebSocket URL, derived from the same base. Overridable via
+// BACKEND_WS_URL.
+export function getBackendWsUrl(): string {
+  const wsUrl = nconf.get('BACKEND_WS_URL');
+  if (wsUrl) return wsUrl;
+  return getBackendBaseUrl()
+    .replace('https://', 'wss://')
+    .replace('http://', 'ws://');
+}

--- a/src/modules/pullClient.ts
+++ b/src/modules/pullClient.ts
@@ -174,8 +174,9 @@ async function pollOnce(): Promise<void> {
     POLL_TIMEOUT_MS
   );
   // See PollRejectedError: a 401 read through the curl fallback parses as a
-  // body with this code instead of throwing.
-  if (data?.code === 'AUTH_REJECTED') {
+  // body with this code instead of throwing. Value mirrors the backend's
+  // ERRORS.PRINT_JOBS.AUTH_REJECTED — keep the two in sync.
+  if (data?.code === 'printJobs.authRejected') {
     throw new PollRejectedError(
       typeof data?.error === 'string' ? data.error : 'invalid venue credentials'
     );

--- a/src/modules/pullClient.ts
+++ b/src/modules/pullClient.ts
@@ -220,7 +220,16 @@ async function pollOnce(): Promise<void> {
       typeof data?.error === 'string' ? data.error : 'invalid venue credentials'
     );
   }
-  const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
+  // A successful poll always carries a jobs array (empty on an idle hold). A
+  // body without one is an error the curl fallback didn't reject (a 5xx JSON
+  // body: curl doesn't fail on HTTP status by default) — throw so the loop
+  // hits its backoff instead of tight-looping with no pause.
+  if (!Array.isArray(data?.jobs)) {
+    throw new Error(
+      `Unexpected poll response without a jobs array: ${JSON.stringify(data)?.slice(0, 200)}`
+    );
+  }
+  const jobs = data.jobs;
   for (const job of jobs) {
     if (!job?.jobId || alreadySeen(job.jobId)) continue;
     dispatchJob(job);

--- a/src/modules/pullClient.ts
+++ b/src/modules/pullClient.ts
@@ -52,9 +52,14 @@ const AUTH_RETRY_MS = 60_000;
 // sync will fill them in), so an un-provisioned PS doesn't hammer the backend.
 const NO_CREDS_RETRY_MS = 5_000;
 
-// The backend flattens into a body code because our curl fallback flattens
-// HTTP status codes into parsed JSON — without this marker a 401 would look
-// like a successful empty poll and the loop would spin with no backoff at all.
+// Raised when the backend rejects the pull channel's credentials. Two triggers:
+// (1) the HTTP status is 401 — the authoritative signal, works even against a
+// backend that predates the poll endpoint (it 401s without the body code); or
+// (2) an upgraded backend flattens the rejection into a body code because our
+// curl fallback flattens HTTP status into parsed JSON. Without either, a 401
+// would look like a successful empty poll and the loop would spin with no
+// backoff at all — which is exactly what happens when the PS ships before the
+// BE+FE poll changes are deployed.
 class PollRejectedError extends Error {}
 // One auth incident log per episode; reset on the first successful poll.
 let authFailureLogged = false;
@@ -125,6 +130,18 @@ async function postJson(
   });
 
   if (result.viaFallback && result.fetchFailure) {
+    // A 401 is an auth rejection, not the transient fetch/proxy failure the
+    // curl fallback exists to paper over — curl just re-fetches the same 401,
+    // and on a backend that predates the poll endpoint the 401 body carries no
+    // authRejected code, so result.data would parse as a successful empty poll
+    // and spin the loop. Surface it as a rejection regardless of body shape so
+    // callers slow-retry. Scoped to the pull path (this postJson serves only
+    // poll + result report); other PS→BE calls are untouched. Non-401 statuses
+    // fall through to the fetch-failure report + normal error backoff below, so
+    // we're not swallowing other errors — only the pull channel's own 401.
+    if (result.fetchFailure.responseStatus === 401) {
+      throw new PollRejectedError('backend rejected credentials (HTTP 401)');
+    }
     const now = Date.now();
     if (now - lastFetchFailureReportAt > FETCH_FAILURE_REPORT_INTERVAL_MS) {
       lastFetchFailureReportAt = now;
@@ -281,8 +298,15 @@ function runCommand(jobId: string, body: () => Promise<void>): void {
 }
 
 async function loop(): Promise<void> {
+  let firstLoop = true;
   while (running) {
     if (!getVenueId() || !getWsSecret()) {
+      if (firstLoop) {
+        logger.warn(
+          `Print-job poll deferred — missing venueId or secret. Retry every ${NO_CREDS_RETRY_MS}.`
+        );
+        firstLoop = false;
+      }
       await sleep(NO_CREDS_RETRY_MS);
       continue;
     }

--- a/src/modules/pullClient.ts
+++ b/src/modules/pullClient.ts
@@ -1,0 +1,231 @@
+/**
+ * Long-poll pull client.
+ *
+ * Primary channel for receiving print jobs: instead of the backend pushing raw
+ * ESC/POS over the WebSocket (fire-and-forget, lost on a half-open socket), the
+ * printer-server pulls. It long-polls the backend for its venue's pending jobs,
+ * runs each through the shared executePrintJob, and reports each outcome back
+ * over HTTP. The WebSocket stays up as the liveness/control channel and still
+ * carries test-page pushes.
+ *
+ * Delivery is at-most-once by design: the backend marks a job claimed the moment
+ * it hands it to a poll, so a job is never re-delivered and can't double-print.
+ * A job lost between claim and print ages out of the queue rather than reprinting
+ * late; staff reprint manually if needed.
+ */
+import { reportFetchFailure } from './api';
+import { getBackendBaseUrl } from './backendUrl';
+import {
+  curlExecJson,
+  httpStatusError,
+  tryFetchWithFallback,
+  withTempJsonPayload,
+} from './http';
+import { executePrintJob, getVenueId, getWsSecret } from './wsClient';
+import logger from './logger';
+
+// Poll timeout must clear the backend's 25s hold with margin, so a healthy idle
+// poll is answered empty by the server rather than aborted here.
+const POLL_TIMEOUT_MS = 30_000;
+const RESULT_TIMEOUT_MS = 10_000;
+// A result report that fails gets retried on this schedule (fresh creds each
+// attempt). The sum stays far below the backend's claim-result timeout, so a
+// report that eventually lands still beats the sweep that would otherwise
+// broadcast a false venue-wide failure for paper that actually printed.
+const RESULT_RETRY_DELAYS_MS = [2_000, 10_000, 30_000];
+// Back-off before retrying after a failed poll (uplink down, backend 5xx), so a
+// hard outage doesn't spin the loop. A successful poll re-polls immediately.
+const POLL_ERROR_BACKOFF_MS = 3_000;
+// Rejected venue credentials won't fix themselves — a /settings sync has to
+// land a new secret — so slow-retry instead of hammering the backend (matches
+// the WS client's auth-failure handling).
+const AUTH_RETRY_MS = 60_000;
+// Re-check cadence while venueId/wsSecret aren't provisioned yet (a /settings
+// sync will fill them in), so an un-provisioned PS doesn't hammer the backend.
+const NO_CREDS_RETRY_MS = 5_000;
+
+// The backend flattens into a body code because our curl fallback flattens
+// HTTP status codes into parsed JSON — without this marker a 401 would look
+// like a successful empty poll and the loop would spin with no backoff at all.
+class PollRejectedError extends Error {}
+// One auth incident log per episode; reset on the first successful poll.
+let authFailureLogged = false;
+
+// Belt-and-suspenders idempotency: the backend already claims a job once, but
+// guard against ever running the same jobId twice. jobId -> expiry (ms).
+const SEEN_TTL_MS = 120_000;
+const seenJobs = new Map<string, number>();
+
+// The poll loop runs continuously, so an unthrottled reportFetchFailure would
+// raise a Slack incident per poll on a machine whose fetch is broken. One
+// report per episode window is plenty — the curl fallback keeps jobs flowing.
+const FETCH_FAILURE_REPORT_INTERVAL_MS = 60 * 60 * 1000;
+let lastFetchFailureReportAt = 0;
+
+let running = false;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+function alreadySeen(jobId: string): boolean {
+  const now = Date.now();
+  for (const [id, expiry] of seenJobs) {
+    if (expiry <= now) seenJobs.delete(id);
+  }
+  if (seenJobs.has(jobId)) return true;
+  seenJobs.set(jobId, now + SEEN_TTL_MS);
+  return false;
+}
+
+// POST JSON to the backend with the same fetch→curl fallback as every other
+// PS→BE call (api.ts): on some venue machines Node's fetch is broken by a
+// proxy while curl works, and without the fallback the pull loop would fail
+// every poll forever while the rest of the app hums along.
+async function postJson(
+  path: string,
+  body: Record<string, unknown>,
+  timeoutMs: number
+): Promise<any> {
+  const url = `${getBackendBaseUrl()}${path}`;
+  const result = await tryFetchWithFallback<any>({
+    curlFn: () =>
+      withTempJsonPayload(body, (tempFilePath) =>
+        curlExecJson(
+          `curl -s -m ${Math.ceil(timeoutMs / 1000)} -X POST "${url}" -H "Content-Type: application/json" --data-binary "@${tempFilePath}"`
+        )
+      ),
+    fetchFn: async () => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(url, {
+          body: JSON.stringify(body),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw httpStatusError(response);
+        }
+        return { data: await response.json() };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    method: 'POST',
+    url,
+  });
+
+  if (result.viaFallback && result.fetchFailure) {
+    const now = Date.now();
+    if (now - lastFetchFailureReportAt > FETCH_FAILURE_REPORT_INTERVAL_MS) {
+      lastFetchFailureReportAt = now;
+      reportFetchFailure(result.fetchFailure).catch(() => {});
+    }
+  }
+  return result.data;
+}
+
+// Report a job's outcome to the backend, retrying on failure. A dropped
+// result is not just a lost metrics row: the backend's sweep would declare the
+// job lost and broadcast a failure toast for paper that actually printed, so
+// the report is worth several attempts. Detached from the pull loop — it must
+// never block or crash it — and creds are re-read per attempt so a secret
+// rotated mid-retry is picked up.
+function reportResult(
+  jobId: string,
+  status: 'failed' | 'success',
+  error?: string
+): void {
+  void (async () => {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const data = await postJson(
+          '/print-jobs/result',
+          { error, jobId, secret: getWsSecret(), status, venueId: getVenueId() },
+          RESULT_TIMEOUT_MS
+        );
+        // The curl fallback surfaces HTTP errors as parsed bodies, so a 4xx
+        // arrives here as data without ok — treat anything unacknowledged as
+        // a failed attempt.
+        if (data?.ok === true) return;
+        throw new Error(
+          typeof data?.error === 'string' ? data.error : 'not acknowledged'
+        );
+      } catch (err) {
+        const delay = RESULT_RETRY_DELAYS_MS[attempt];
+        if (delay === undefined) {
+          logger.error(
+            `Failed to report print result for job ${jobId} after ${attempt + 1} attempts:`,
+            err
+          );
+          return;
+        }
+        await sleep(delay);
+      }
+    }
+  })();
+}
+
+async function pollOnce(): Promise<void> {
+  const data = await postJson(
+    '/print-jobs/poll',
+    { secret: getWsSecret(), venueId: getVenueId() },
+    POLL_TIMEOUT_MS
+  );
+  // See PollRejectedError: a 401 read through the curl fallback parses as a
+  // body with this code instead of throwing.
+  if (data?.code === 'AUTH_REJECTED') {
+    throw new PollRejectedError(
+      typeof data?.error === 'string' ? data.error : 'invalid venue credentials'
+    );
+  }
+  const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
+  for (const job of jobs) {
+    if (!job?.jobId || alreadySeen(job.jobId)) continue;
+    // Only printRaw exists today; NACK anything else instead of base64-decoding
+    // a future job kind and blasting it to a thermal printer as ESC/POS.
+    if (job.type && job.type !== 'printRaw') {
+      logger.error(
+        `Skipping print job ${job.jobId} with unsupported type ${job.type}`
+      );
+      reportResult(job.jobId, 'failed', 'UNSUPPORTED_TYPE');
+      continue;
+    }
+    executePrintJob(job, reportResult);
+  }
+}
+
+async function loop(): Promise<void> {
+  while (running) {
+    if (!getVenueId() || !getWsSecret()) {
+      await sleep(NO_CREDS_RETRY_MS);
+      continue;
+    }
+    try {
+      await pollOnce();
+      authFailureLogged = false;
+    } catch (err) {
+      if (err instanceof PollRejectedError) {
+        if (!authFailureLogged) {
+          authFailureLogged = true;
+          logger.error(
+            `Print-job poll rejected (${err.message}) — check venueId/wsSecret. Slow-retrying every ${AUTH_RETRY_MS}ms`
+          );
+        }
+        await sleep(AUTH_RETRY_MS);
+        continue;
+      }
+      logger.error('Print-job poll failed:', err);
+      await sleep(POLL_ERROR_BACKOFF_MS);
+    }
+  }
+}
+
+// Start the pull loop. Idempotent — a second call while already running no-ops.
+export function initPullClient(): void {
+  if (running) return;
+  running = true;
+  logger.info('Starting print-job pull loop');
+  void loop();
+}

--- a/src/modules/pullClient.ts
+++ b/src/modules/pullClient.ts
@@ -21,7 +21,15 @@ import {
   tryFetchWithFallback,
   withTempJsonPayload,
 } from './http';
-import { executePrintJob, getVenueId, getWsSecret } from './wsClient';
+import scanNetworkForConnections from './network';
+import { checkPrinters } from './printer';
+import {
+  executePrintJob,
+  getPrinterVersion,
+  getVenueId,
+  getWsSecret,
+  triggerRestart,
+} from './wsClient';
 import logger from './logger';
 
 // Poll timeout must clear the backend's 25s hold with margin, so a healthy idle
@@ -135,14 +143,22 @@ async function postJson(
 function reportResult(
   jobId: string,
   status: 'failed' | 'success',
-  error?: string
+  error?: string,
+  result?: unknown
 ): void {
   void (async () => {
     for (let attempt = 0; ; attempt++) {
       try {
         const data = await postJson(
           '/print-jobs/result',
-          { error, jobId, secret: getWsSecret(), status, venueId: getVenueId() },
+          {
+            error,
+            jobId,
+            result,
+            secret: getWsSecret(),
+            status,
+            venueId: getVenueId(),
+          },
           RESULT_TIMEOUT_MS
         );
         // The curl fallback surfaces HTTP errors as parsed bodies, so a 4xx
@@ -170,7 +186,13 @@ function reportResult(
 async function pollOnce(): Promise<void> {
   const data = await postJson(
     '/print-jobs/poll',
-    { secret: getWsSecret(), venueId: getVenueId() },
+    // Piggyback the version so the backend can surface it without depending on
+    // the WS register — the pull channel is the primary transport.
+    {
+      secret: getWsSecret(),
+      venueId: getVenueId(),
+      version: getPrinterVersion(),
+    },
     POLL_TIMEOUT_MS
   );
   // See PollRejectedError: a 401 read through the curl fallback parses as a
@@ -184,17 +206,78 @@ async function pollOnce(): Promise<void> {
   const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
   for (const job of jobs) {
     if (!job?.jobId || alreadySeen(job.jobId)) continue;
-    // Only printRaw exists today; NACK anything else instead of base64-decoding
-    // a future job kind and blasting it to a thermal printer as ESC/POS.
-    if (job.type && job.type !== 'printRaw') {
+    dispatchJob(job);
+  }
+}
+
+/**
+ * Route one claimed job by its type. Prints (printRaw/testPrint) go through the
+ * shared executePrintJob (per-printer serialization). Control commands run
+ * immediately and in parallel — they must NOT queue behind print bytes, or a
+ * user checking printer status during a print rush would wait for the queue to
+ * drain. Each command is fire-and-forget: it reports its own result over HTTP,
+ * so a slow probe never stalls the poll loop that dispatches the rest.
+ */
+function dispatchJob(job: {
+  data?: unknown;
+  jobId: string;
+  printerIp?: string;
+  printerPort?: string;
+  type?: string;
+}): void {
+  switch (job.type) {
+    // Undefined type is a legacy/print row; treat it as a raw print.
+    case undefined:
+    case 'printRaw':
+    case 'testPrint':
+      executePrintJob(job, reportResult);
+      return;
+    case 'checkPrinters':
+      runCommand(job.jobId, async () =>
+        reportResult(job.jobId, 'success', undefined, await checkPrinters())
+      );
+      return;
+    case 'scanNetwork':
+      runCommand(job.jobId, async () =>
+        reportResult(
+          job.jobId,
+          'success',
+          undefined,
+          await scanNetworkForConnections()
+        )
+      );
+      return;
+    case 'restart':
+      // Ack before exiting so the backend row settles; the process may die
+      // before the report lands, which is harmless (the backend doesn't await
+      // a restart result). Then trigger the actual restart.
+      reportResult(job.jobId, 'success');
+      triggerRestart();
+      return;
+    default:
+      // A genuinely unknown kind: don't base64-decode it to a printer. NACK so
+      // the backend's awaiting resolver gets a definite answer, not a timeout.
       logger.error(
-        `Skipping print job ${job.jobId} with unsupported type ${job.type}`
+        `Skipping job ${job.jobId} with unsupported type ${job.type}`
       );
       reportResult(job.jobId, 'failed', 'UNSUPPORTED_TYPE');
-      continue;
-    }
-    executePrintJob(job, reportResult);
   }
+}
+
+/**
+ * Run a control command's async body detached from the poll loop, reporting a
+ * failed result if it throws. Keeps the loop dispatching subsequent jobs while
+ * a slow probe (offline-printer retries, LAN scan) runs.
+ */
+function runCommand(jobId: string, body: () => Promise<void>): void {
+  void body().catch((err) => {
+    logger.error(`Command job ${jobId} failed:`, err);
+    reportResult(
+      jobId,
+      'failed',
+      err instanceof Error ? err.message : String(err)
+    );
+  });
 }
 
 async function loop(): Promise<void> {

--- a/src/modules/wsClient.ts
+++ b/src/modules/wsClient.ts
@@ -227,7 +227,13 @@ function enqueuePrinterJob(key: string, task: () => Promise<void>): void {
   const next = prev
     .catch(() => {})
     .then(task)
-    .catch(() => {})
+    .catch((err) => {
+      // executePrintJob has its own try/catch and reports failures via its
+      // callback, so a rejection surfacing here is an unexpected fault (e.g. a
+      // bug before that try/catch). Log it once and keep the per-printer chain
+      // alive for the jobs queued behind it.
+      logger.error(`Unexpected error in printer queue for ${key}:`, err);
+    })
     .then(() => new Promise<void>((r) => setTimeout(r, INTER_JOB_DELAY_MS)));
   printerQueues.set(key, next);
   // Drop the entry once it settles, unless a newer job has already chained on.

--- a/src/modules/wsClient.ts
+++ b/src/modules/wsClient.ts
@@ -14,12 +14,11 @@ import {
 } from 'node-thermal-printer';
 import nconf from 'nconf';
 import { reportWebSocketFailure } from './api';
+import { getBackendWsUrl } from './backendUrl';
 import { isUSBPrinterOnline } from './common';
 import logger from './logger';
 import scanNetworkForConnections from './network';
 import { checkPrinters } from './printer';
-
-nconf.argv().env().file({ file: './config.json' });
 
 let ws: WebSocket | null = null;
 let reconnectAttempts = 0;
@@ -139,17 +138,6 @@ function clearReconnectTimer(): void {
   }
 }
 
-function getBackendWsUrl(): string {
-  const apiUrl =
-    nconf.get('QUICKORD_API_URL') || 'https://api.quickord.com/graphql';
-  const wsUrl = nconf.get('BACKEND_WS_URL');
-  if (wsUrl) return wsUrl;
-  return apiUrl
-    .replace('/graphql', '')
-    .replace('https://', 'wss://')
-    .replace('http://', 'ws://');
-}
-
 // Current PS version from the `version` file at the app root. Reported in the
 // register payload so the backend can surface current-vs-latest version info.
 function getPrinterVersion(): string {
@@ -172,7 +160,7 @@ function getPrinterVersion(): string {
 }
 
 // Get registered venueId from in-memory settings object.
-function getVenueId(): string {
+export function getVenueId(): string {
   try {
     const { getSettings } = require('./settings');
     const settings = getSettings();
@@ -186,7 +174,7 @@ function getVenueId(): string {
 // local by the frontend, same path as venueId), with an env fallback for
 // manual provisioning. Fail-closed: no hardcoded fallback, so a leaked
 // shared key can no longer impersonate other venues.
-function getWsSecret(): string {
+export function getWsSecret(): string {
   try {
     const { getSettings } = require('./settings');
     const secret = getSettings()?.wsSecret;
@@ -212,9 +200,20 @@ export function setRestartHandler(fn: () => void): void {
 // request — this is the authoritative guard regardless of how jobs arrive.
 const printerQueues = new Map<string, Promise<void>>();
 
+// Pause between chained jobs to the same printer, giving it time to finish
+// cutting/feeding before the next connection opens — sendToPrinter resolves on
+// socket close, not print completion, so back-to-back connects would hit some
+// printer models mid-cut. Parity with the backend push path's
+// INTER_COPY_DELAY_MS, which paced copies before they moved to the pull channel.
+const INTER_JOB_DELAY_MS = 500;
+
 function enqueuePrinterJob(key: string, task: () => Promise<void>): void {
   const prev = printerQueues.get(key) ?? Promise.resolve();
-  const next = prev.catch(() => {}).then(task);
+  const next = prev
+    .catch(() => {})
+    .then(task)
+    .catch(() => {})
+    .then(() => new Promise<void>((r) => setTimeout(r, INTER_JOB_DELAY_MS)));
   printerQueues.set(key, next);
   // Drop the entry once it settles, unless a newer job has already chained on.
   void next.finally(() => {
@@ -329,71 +328,94 @@ function checkPrinterConnectivity(ip: string, port: number): Promise<boolean> {
   });
 }
 
+// Execute a single raw print job and report its outcome via `reportResult`.
+// Shared by the WebSocket push path (test pages, result reported over the WS)
+// and the long-poll pull path (regular jobs, result reported over HTTP), so the
+// serialization, transport selection, and error classification stay identical
+// regardless of how the job arrived. Fire-and-forget: it enqueues onto the
+// per-printer chain and returns; the result flows back through the callback.
+export function executePrintJob(
+  job: {
+    data?: unknown;
+    jobId?: string;
+    printerIp?: string;
+    printerPort?: string;
+  },
+  reportResult: (
+    jobId: string,
+    status: 'failed' | 'success',
+    error?: string
+  ) => void
+): void {
+  const { data, jobId, printerIp, printerPort } = job;
+
+  // A job needs an id, a base64 string payload, and at least one transport
+  // target: an IP for TCP printers, or a device path in printerPort for local
+  // shared/USB/serial printers. `data` must be a string — a non-string would
+  // throw in Buffer.from below and leave the job unacknowledged, so reject it
+  // here with a terminal result instead.
+  if (
+    !jobId ||
+    typeof data !== 'string' ||
+    !data ||
+    (!printerIp && !printerPort)
+  ) {
+    logger.error('Invalid print job: missing required fields');
+    if (jobId) reportResult(jobId, 'failed', 'Missing required fields');
+    return;
+  }
+
+  const buffer = Buffer.from(data, 'base64');
+
+  // Key the queue by the physical target (ip for TCP, device path for local) so
+  // jobs to the same printer serialize but different printers stay parallel.
+  const queueKey = printerIp || printerPort!;
+  enqueuePrinterJob(queueKey, async () => {
+    let target: string;
+    let dispatch: Promise<unknown>;
+
+    if (printerIp) {
+      const parsed = printerPort ? parseInt(printerPort, 10) : NaN;
+      const port = Number.isFinite(parsed) ? parsed : 9100;
+      target = `${printerIp}:${port}`;
+      logger.info(
+        `Received print job ${jobId} for ${target} (${buffer.length} bytes)`
+      );
+      dispatch = sendToPrinter(printerIp, port, buffer);
+    } else {
+      target = printerPort!;
+      logger.info(
+        `Received print job ${jobId} for local printer ${target} (${buffer.length} bytes)`
+      );
+      dispatch = sendToLocalPrinter(printerPort!, buffer);
+    }
+
+    try {
+      await dispatch;
+      logger.info(`Print job ${jobId} sent successfully to ${target}`);
+      reportResult(jobId, 'success');
+    } catch (err: any) {
+      logger.error(`Print job ${jobId} failed for ${target}:`, err);
+      // Surface a STABLE code, never the raw socket message. A printer that's
+      // powered off / unplugged fails with different OS errors depending on
+      // ARP-cache timing (EHOSTDOWN on the first try, a socket timeout once the
+      // stale ARP entry is flushed), but to the user it's the same condition:
+      // the printer is unreachable. The frontend maps PRINTER_OFFLINE to one
+      // translated toast.
+      reportResult(jobId, 'failed', classifyPrinterError(err));
+    }
+  });
+}
+
 async function handleMessage(raw: string): Promise<void> {
   try {
     const msg = JSON.parse(raw);
 
     switch (msg.type) {
       case 'printRaw': {
-        const { jobId, printerIp, printerPort, data } = msg;
-
-        // A job needs an id, a base64 string payload, and at least one
-        // transport target: an IP for TCP printers, or a device path in
-        // printerPort for local shared/USB/serial printers. `data` must be a
-        // string — a non-string would throw in Buffer.from below and leave the
-        // job unacknowledged, so reject it here with a terminal result instead.
-        if (
-          !jobId ||
-          typeof data !== 'string' ||
-          !data ||
-          (!printerIp && !printerPort)
-        ) {
-          logger.error('Invalid printRaw message: missing required fields');
-          if (jobId) sendResult(jobId, 'failed', 'Missing required fields');
-          return;
-        }
-
-        const buffer = Buffer.from(data, 'base64');
-
-        // Key the queue by the physical target (ip for TCP, device path for
-        // local) so jobs to the same printer serialize but different printers
-        // stay parallel.
-        const queueKey = printerIp || printerPort;
-        enqueuePrinterJob(queueKey, async () => {
-          let target: string;
-          let dispatch: Promise<unknown>;
-
-          if (printerIp) {
-            const parsed = printerPort ? parseInt(printerPort, 10) : NaN;
-            const port = Number.isFinite(parsed) ? parsed : 9100;
-            target = `${printerIp}:${port}`;
-            logger.info(
-              `Received print job ${jobId} for ${target} (${buffer.length} bytes)`
-            );
-            dispatch = sendToPrinter(printerIp, port, buffer);
-          } else {
-            target = printerPort;
-            logger.info(
-              `Received print job ${jobId} for local printer ${target} (${buffer.length} bytes)`
-            );
-            dispatch = sendToLocalPrinter(printerPort, buffer);
-          }
-
-          try {
-            await dispatch;
-            logger.info(`Print job ${jobId} sent successfully to ${target}`);
-            sendResult(jobId, 'success');
-          } catch (err: any) {
-            logger.error(`Print job ${jobId} failed for ${target}:`, err);
-            // Surface a STABLE code, never the raw socket message. A printer
-            // that's powered off / unplugged fails with different OS errors
-            // depending on ARP-cache timing (EHOSTDOWN on the first try, a
-            // socket timeout once the stale ARP entry is flushed), but to the
-            // user it's the same condition: the printer is unreachable. The
-            // frontend maps PRINTER_OFFLINE to one translated toast.
-            sendResult(jobId, 'failed', classifyPrinterError(err));
-          }
-        });
+        // Push path: the backend still pushes test pages over the WS and awaits
+        // the result frame. Regular jobs now arrive via the long-poll pull loop.
+        executePrintJob(msg, sendResult);
         break;
       }
 
@@ -547,7 +569,14 @@ function connect(): void {
     ws!.send(
       JSON.stringify({
         type: 'printerServerRegister',
-        data: { secret, venueId, version: getPrinterVersion() },
+        // supportsPull tells the backend this build runs the long-poll loop, so
+        // it queues print jobs for us to pull instead of pushing them over the WS.
+        data: {
+          secret,
+          supportsPull: true,
+          venueId,
+          version: getPrinterVersion(),
+        },
       })
     );
     registeredVenueId = venueId;

--- a/src/modules/wsClient.ts
+++ b/src/modules/wsClient.ts
@@ -104,7 +104,11 @@ function classifyWsError(err: any): {
   // An intercepting HTTP proxy that doesn't speak the WS upgrade replies with a
   // non-101 status; the ws library throws "Unexpected server response: <code>".
   if (/unexpected server response/i.test(message)) {
-    return { category: 'PROXY_OR_UNEXPECTED_RESPONSE', code: code || message, message };
+    return {
+      category: 'PROXY_OR_UNEXPECTED_RESPONSE',
+      code: code || message,
+      message,
+    };
   }
   // Corporate MITM proxy / antivirus TLS interception.
   if (
@@ -140,7 +144,7 @@ function clearReconnectTimer(): void {
 
 // Current PS version from the `version` file at the app root. Reported in the
 // register payload so the backend can surface current-vs-latest version info.
-function getPrinterVersion(): string {
+export function getPrinterVersion(): string {
   // Read cwd-relative first, exactly like autoupdate.ts: the packaged nexe exe's
   // __dirname points into the virtual snapshot FS and misses the real `version`
   // file sitting next to the exe, so the __dirname path throws in the Windows
@@ -192,6 +196,17 @@ export function setRestartHandler(fn: () => void): void {
   restartHandler = fn;
 }
 
+// Invoke the registered restart trigger. Shared by the WS restartRequest
+// handler and the long-poll pull client's restart command, so a remote restart
+// works over either channel. No-ops (with a warning) if index.ts never wired one.
+export function triggerRestart(): void {
+  if (restartHandler) {
+    restartHandler();
+  } else {
+    logger.warn('No restart handler registered, ignoring restart request');
+  }
+}
+
 // Per-printer job queue. Thermal printers accept a single connection at a time,
 // so two overlapping jobs to one device (copies, or two independent print
 // requests at once) collide and only one ticket comes out. Chaining each job
@@ -241,7 +256,10 @@ function classifyPrinterError(err: any): string {
     'ETIMEDOUT',
     'EPIPE',
   ];
-  if (offlineCodes.includes(code) || /timeout|offline|not found/i.test(message)) {
+  if (
+    offlineCodes.includes(code) ||
+    /timeout|offline|not found/i.test(message)
+  ) {
     return 'PRINTER_OFFLINE';
   }
   return 'PRINTER_ERROR';
@@ -457,11 +475,7 @@ async function handleMessage(raw: string): Promise<void> {
 
       case 'restartRequest': {
         logger.info('Received restart request from backend');
-        if (restartHandler) {
-          restartHandler();
-        } else {
-          logger.warn('No restart handler registered, ignoring restart request');
-        }
+        triggerRestart();
         break;
       }
 


### PR DESCRIPTION
[Task](https://partners.flarmio.com/admin/dev/all/tasks?status=todo%2Cin_progress%2Cin_review%2Cpaused%2Cdone&assignee=69fd2d4b8ccea86c7add5aae&savedView=6a0d8b33cdba6716a23271b8&project=quickord&task=6a4b8bd99512a4d89b357c2c)

## Summary

Adds the printer-server side of the print-queue long-poll feature (backend PR in quickord-be, FE PR in quickord-fe):

- **Pull client** (`src/modules/pullClient.ts`): long-polls `/print-jobs/poll` for the venue's queued jobs, executes each through the shared `executePrintJob`, and reports each outcome to `/print-jobs/result`. The WebSocket stays up as the liveness/control channel and still carries test pages.
- **`executePrintJob` extraction** (`src/modules/wsClient.ts`): the WS printRaw handler and the pull loop share the same validation, per-printer serialization, transport selection, and stable error codes.
- **`backendUrl.ts`**: one place derives the backend HTTP and WS URLs so the two channels can never point at different hosts.
- **Register payload** advertises `supportsPull: true` so the backend queues jobs instead of pushing them.

## Hardening (from pre-ship review)

- Result reports retry on a 2s/10s/30s schedule with fresh credentials per attempt, and treat unacknowledged bodies (a 4xx read through the curl fallback) as failures — a single dropped report no longer becomes a false venue-wide "print failed" toast for paper that actually printed.
- Rejected venue credentials (backend replies `code: AUTH_REJECTED`) slow-retry every 60s with one log per episode, instead of spinning sub-second through the curl fallback and flooding the log.
- 500ms inter-job pause per printer so back-to-back jobs don't hit slow printer models mid-cut.

## Rollout order

Deploy quickord-fe first, then quickord-be, then release this. A venue only switches to the pull channel once its PS updates and registers with `supportsPull`; until then the backend keeps pushing over the WS.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run jest:no-coverage` — 1 suite, 1 test passing
- [ ] Manual: venue machine smoke test (poll loop claims and prints, results land, test page still prints synchronously)