### PR TITLE
feat(autoupdate): report fetch failures on the update path too

### DIFF
--- a/src/autoupdate/autoupdate.ts
+++ b/src/autoupdate/autoupdate.ts
@@ -18,8 +18,23 @@ import {
   curlExec,
   curlExecJson,
   httpStatusError,
+  HttpResult,
   tryFetchWithFallback,
 } from '../modules/http';
+import { reportFetchFailure } from '../modules/api';
+
+// The update path uses tryFetchWithFallback exactly like the runtime paths
+// (poll/apiCall/common) but never looked at viaFallback, so a fetch that failed
+// and only succeeded via the curl fallback went unreported here. Mirror the
+// runtime wiring: when the update download/version check falls back to curl,
+// report it so a fetch that is quietly broken on the update path is visible too.
+// Fire-and-forget, same as the runtime call sites; a report failure must never
+// hold up or break an update.
+function reportIfViaFallback<T>(result: HttpResult<T>): void {
+  if (result.viaFallback && result.fetchFailure) {
+    reportFetchFailure(result.fetchFailure).catch(() => {});
+  }
+}
 
 nconf.argv().env().file({ file: './config.json' });
 let path2 = '';
@@ -210,6 +225,7 @@ async function fetchLatestReleaseVersion(): Promise<string | null> {
           `curl -L -H "User-Agent: quickord-printer-server" "${versionUrl}"`
         ),
     });
+    reportIfViaFallback(result);
     const releaseData = result.data;
     const tagName = releaseData.tag_name;
 
@@ -262,7 +278,7 @@ export async function downloadLatestCode(): Promise<string | null> {
   const srcDir = await fsp.mkdtemp(tempDirPath);
   const zipPath = path.resolve(srcDir, 'quickord-cashier-server.zip');
 
-  await tryFetchWithFallback<void>({
+  const downloadResult = await tryFetchWithFallback<void>({
     url,
     method: 'GET',
     fetchFn: async () => {
@@ -275,6 +291,7 @@ export async function downloadLatestCode(): Promise<string | null> {
       await curlExec(`curl -L "${url}" -o "${zipPath}"`);
     },
   });
+  reportIfViaFallback(downloadResult);
 
   // Extract zip
   const tempCodePath = path.resolve(srcDir, 'code');

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,14 @@ const main = async () => {
     }
 
     console.log('Update path:', process.argv);
+    // autoUpdate's normal-boot download reports fetch failures via
+    // reportFetchFailure(), which attributes the incident to a venueId resolved
+    // from the in-memory settings. Load them now on the normal-boot branch only (empty args);
+    // the --update/--remove branches chdir and relaunch and must not read/create
+    // settings here, and they never hit the reporting path anyway.
+    if (args.length === 0) {
+      await loadSettings();
+    }
     try {
       await autoUpdate(args); // Ensure updatePath is a string
     } catch (err) {


### PR DESCRIPTION
[Task](https://partners.flarmio.com/admin/dev/all/tasks?savedView=69fdb53afa09045de57bf516&project=quickord&status=todo%2Cin_progress%2Cin_review%2Cpaused%2Cdone&assignee=69fd2d4b8ccea86c7add5aae&task=6a61f381125c9b4a9341196f)

## Τι κάνει

Στα runtime paths (poll / apiCall / common) όταν το `fetch` αποτυγχάνει και πετυχαίνει το curl fallback, καλείται το `reportFetchFailure` → BE `addError` με `Problem:` prefix → Slack incident. Το **update path** όμως (`fetchLatestReleaseVersion` + το download του release zip στο `downloadLatestCode`) χρησιμοποιεί το ίδιο `tryFetchWithFallback` αλλά **δεν** έλεγχε ποτέ το `viaFallback` — άρα ένα fetch που έσπαγε σιωπηλά στο update path δεν παρήγαγε κανένα incident.

## Αλλαγή

- Νέος helper `reportIfViaFallback(result)` που αναπαράγει τη λογική των runtime call sites: `if (result.viaFallback && result.fetchFailure) reportFetchFailure(...).catch(() => {})`.
- Κλήση του και στα δύο update-path fetch calls (version check + zip download).
- Fire-and-forget με `.catch()`, ώστε μια αποτυχία στο reporting να μην μπλοκάρει/σπάει ποτέ ένα update.

Έτσι μαθαίνουμε αν στο update path απέτυχε το fetch αλλά πέτυχε το curl.

## Notes

- Το `autoupdate → api` δεν εισάγει νέο κύκλο imports: το `api.ts` δεν κάνει top-level import το `autoupdate`/`wsClient` (το `wsClient` το φορτώνει lazily), οπότε το `reportFetchFailure` είναι πλήρως ορισμένο όταν φορτώνεται το `autoupdate`.
- `tsc --noEmit` περνάει.

🤖 Generated with [Claude Code](https://claude.com/claude-code)