### PR TITLE
ci: pin windows-2025 runner & verbose nexe build logs

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   create:
-    runs-on: windows-latest
+    # Pinned: Node 24's vcbuild.bat can't detect VS 2026, which windows-latest now ships.
+    runs-on: windows-2025
 
     steps:
       # Checkout repo

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:watch": "tsx watch ./src --exec 'npm run build'",
     "build:bundle": "esbuild ./dist/src/index.js --bundle --platform=node --target=node24.8.0 --outfile=./dist/bundle.cjs --external:serialport --external:@serialport/bindings* --external:*.node",
     "----------------------------------Build----------------------------------": "",
-    "build:exe": "npm run build:bundle && nexe ./dist/bundle.cjs --target windows-x64-24.8.0 --build --external:serialport --external:@serialport/bindings* --external:*.node --output builds/builds/printerServer.exe",
+    "build:exe": "npm run build:bundle && nexe ./dist/bundle.cjs --target windows-x64-24.8.0 --build --verbose --external:serialport --external:@serialport/bindings* --external:*.node --output builds/builds/printerServer.exe",
     "copy-bindings": "cp -r node_modules/@serialport* builds/node_modules/@serialport"
   },
   "keywords": [],


### PR DESCRIPTION
[Task](https://partners.flarmio.com/admin/dev/all/tasks?savedView=6a0d8b33cdba6716a23271b8&project=quickord&status=todo%2Cin_progress%2Cin_review%2Cpaused%2Cdone&assignee=69fd2d4b8ccea86c7add5aae&task=6a7f1b02e2554fe2b902b85a)

## Why

The [main-branch release run for #135](https://github.com/Knorcedger/quickord-printer-server/actions/runs/31795491107) failed with `vcbuild.bat nosign release x64 exited with code: 1`.

Root cause (two things compounding):

1. The `nexe-Windows-24.8.0` Actions cache was evicted after 8 quiet days (GitHub deletes caches unused for 7 days), forcing the first build-Node-from-source run in months — every retained run since May had restored the cached binary and never exercised this path.
2. Meanwhile (between the Jun 9 and Jun 23 runs) GitHub rolled the `windows-latest` alias from the `windows-2025` image (VS 2022) to `windows-2025-vs2026`. Node 24's `vcbuild.bat` can't detect VS 2026, so the source build dies ~2s after source extraction, at toolchain detection.

## Changes

- **Pin `runs-on: windows-2025`** — the image that still ships VS 2022, which `vcbuild.bat` can find. Alias rolls of `windows-latest` can no longer silently swap the compiler under this workflow.
- **Add `--verbose` to the nexe build** in `build:exe` so vcbuild's actual output lands in CI logs instead of a bare exit code.

## Notes

- The repo's Actions cache is currently completely empty, so the first run after merge will do the full ~30–40 min Node source build, then repopulate the cache; subsequent runs return to normal speed.
- Merging this triggers a release run (as any main push does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)