### PR TITLE
ci: move to windows-2022 runner (only image left with VS 2022)

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   create:
-    # Pinned: Node 24's vcbuild.bat can't detect VS 2026, which windows-latest now ships.
-    runs-on: windows-2025
+    # Node 24.8's vcbuild.bat needs VS 2022; windows-2025/latest now ship only VS 2026.
+    runs-on: windows-2022
 
     steps:
       # Checkout repo


### PR DESCRIPTION
[Task](https://partners.flarmio.com/admin/dev/all/tasks?savedView=6a0d8b33cdba6716a23271b8&project=quickord&status=todo%2Cin_progress%2Cin_review%2Cpaused%2Cdone&assignee=69fd2d4b8ccea86c7add5aae&task=6a7f1b02e2554fe2b902b85a)

## Why the pin in #137 didn't work

The Aug 18 run ([32109210650](https://github.com/Knorcedger/quickord-printer-server/actions/runs/32109210650)) requested `windows-2025` but the job log shows GitHub served the **`windows-2025-vs2026`** image anyway — GitHub has since migrated the `windows-2025` label itself onto the VS 2026 image. Per [actions/runner-images](https://github.com/actions/runner-images#available-images), `windows-latest`, `windows-2025`, and `windows-2025-vs2026` are now all the same VS-2026-only image.

The `--verbose` flag from #137 did surface the real error this time:

```
Using ClangCL because the Node.js version being compiled is >= 24.
Looking for Visual Studio 2022
Failed to find a suitable Visual Studio installation or Clang compiler/LLVM toolset.
```

Node 24.8.0's `vcbuild.bat` searches for VS in version range `[17.6,18.0)` — VS 2022 only. VS 2026 (18.x) support was only added to `vcbuild.bat` in Node **24.14.0** (Feb 2026).

## Fix

Use `windows-2022` — the last hosted image that ships VS 2022 (Enterprise 17.14, including the `VC.Llvm.Clang` + `ClangToolset` components the Node ≥24 build requires). This is the same VS generation that successfully built the cached 24.8.0 binary back in Sept 2025.

## Caveats

- First post-merge run still builds Node from source (~30–40 min) since the nexe cache is empty; the cache is keyed on `runner.os` (`Windows`), so it carries over across image changes.
- `windows-2022` is the oldest Windows image and will eventually be retired. The durable fix is bumping the nexe target to Node ≥24.14 (VS 2026-aware vcbuild) — left out of this PR deliberately since it changes the shipped runtime and needs its own testing.